### PR TITLE
Print out error notice when linting fails

### DIFF
--- a/kustomize/binaries.py
+++ b/kustomize/binaries.py
@@ -47,7 +47,7 @@ def run_piped_commands(commands: list) -> CompletedProcess:
     return result
 
 
-def shell(shell_command, fail=False):
+def shell(shell_command):
     """
     Run a shell command with pipes and print it out, beautified, beforehand
     """
@@ -58,13 +58,10 @@ def shell(shell_command, fail=False):
     commands = [cmd.strip() for cmd in shell_command.split('|')]
     result = run_piped_commands(commands)
 
-    if result.stdout:
-        print(result.stdout.strip())
+    if result.stdout and result.stdout.strip():
+        print(result.stdout.strip(), file=sys.stdout)
 
-    if result.returncode:
-        msg = result.stderr.strip()
-        if fail:
-            raise SystemExit(msg)
-        print(msg, file=sys.stderr)
+    if result.stderr and result.stderr.strip():
+        print(result.stderr.strip(), file=sys.stderr)
 
     return result

--- a/kustomize/commands/lint.py
+++ b/kustomize/commands/lint.py
@@ -1,6 +1,8 @@
 """
 Perform validation of manifest built by kustomize
 """
+import sys
+
 from ..binaries import realpath, shell
 
 
@@ -22,6 +24,10 @@ def lint(folders, edit, fail_fast, force_color, ignore_missing_schemas):
     status = 0
     for folder in folders:
         command = f"{kustomize} build {folder} | {kubeval} {kubeval_options}"
-        status += shell(command, fail=fail_fast).returncode
+        status += shell(command).returncode
+        if status and fail_fast:
+            break
 
+    if status:
+        print("Validation of your manifests FAILED.", file=sys.stderr)
     raise SystemExit(status)

--- a/tests/test_binaries.py
+++ b/tests/test_binaries.py
@@ -76,7 +76,7 @@ def test_shell_command(mock_run_piped_commands, mock_print):
     assert exec_location not in str(mock_print.mock_calls[0]), \
         "Output doesn't seem to be beautified"
     assert mock_run_piped_commands.called, \
-        f"run_piped_commands() is not called"
+        "run_piped_commands() is not called"
 
 
 def test_shell_failing_returncode():
@@ -87,11 +87,3 @@ def test_shell_failing_returncode():
 
     assert result.returncode, \
         "Non-zero status code expected, zero received"
-
-
-def test_shell_failing_systemexit():
-    """
-    Does an invalid command abort execution when ``fail`` is set?
-    """
-    with pytest.raises(SystemExit):
-        kustomize.binaries.shell('/non/existing/command', fail=True)

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -20,8 +20,8 @@ def test_cli_command(mock_command):
     assert mock_command.called
 
 
-@patch('kustomize.commands.lint.shell')
-def test_fail_fast(mock_shell):
+@patch('builtins.print')
+def test_fail_fast(mock_print):
     """
     Is the correct code called when invoked with option?
     """
@@ -29,8 +29,8 @@ def test_fail_fast(mock_shell):
             pytest.raises(SystemExit):
         kustomize.cli.main()
 
-    assert str(mock_shell.mock_calls[0]).endswith(', fail=True)'), \
-        "shell() function not called with fail=True"
+    assert str(mock_print.call_args).startswith(
+        "call('Validation of your manifests FAILED.'")
 
 
 @patch('kustomize.commands.lint.shell')


### PR DESCRIPTION
The output of kubeval does not always convey that there was an error. We make those situations a bit clearer by printing out a final FAILURE notice.