### PR TITLE
Upload coverage report to Codacy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,3 +33,8 @@ jobs:
       run: python -m pip install --upgrade setuptools pip wheel tox-gh-actions
     - name: Run tests
       run: tox
+    - name: Upload coverage report
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: tests/coverage-report.xml


### PR DESCRIPTION
Uploads coverage data generated with unit test execution to Codacy.

Implementation information comes from:

- https://docs.codacy.com/coverage-reporter/#uploading-coverage
- https://github.com/codacy/codacy-coverage-reporter